### PR TITLE
Make intervals fire immediately when `at` has passed

### DIFF
--- a/src/timer.rs
+++ b/src/timer.rs
@@ -120,7 +120,7 @@ impl Timer {
         let sleep = if at > now {
             self.sleep(at - now)
         } else {
-            self.sleep(dur)
+            self.sleep(Duration::from_millis(0))
         };
 
         interval::new(sleep, dur)

--- a/tests/test_timer.rs
+++ b/tests/test_timer.rs
@@ -258,3 +258,45 @@ fn test_interval_twice() {
 
     e1.assert_is_about(dur * 2);
 }
+
+#[test]
+fn test_interval_at_once() {
+    let timer = Timer::default();
+    let delay = Duration::from_millis(500);
+    let dur = Duration::from_millis(300);
+    let mut interval = timer.interval_at(Instant::now() + delay, dur).wait();
+
+    let e1 = support::time(|| {
+        interval.next();
+    });
+
+    e1.assert_is_about(delay);
+}
+
+#[test]
+fn test_interval_at_twice() {
+    let timer = Timer::default();
+    let delay = Duration::from_millis(500);
+    let dur = Duration::from_millis(300);
+    let mut interval = timer.interval_at(Instant::now() + delay, dur).wait();
+
+    let e1 = support::time(|| {
+        interval.next();
+        interval.next();
+    });
+
+    e1.assert_is_about(delay + dur);
+}
+
+#[test]
+fn test_interval_at_past() {
+    let timer = Timer::default();
+    let dur = Duration::from_millis(300);
+    let mut interval = timer.interval_at(Instant::now() - Duration::from_millis(200), dur).wait();
+
+    let e1 = support::time(|| {
+        interval.next();
+    });
+
+    e1.assert_is_about(Duration::from_millis(0));
+}


### PR DESCRIPTION
Fixes #12