### PR TITLE
Enhance Builder.num_slots() documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,6 +149,8 @@ impl Builder {
 
     /// Set the number of slots in the timer wheel.
     ///
+    /// The number of slots must be a power of two.
+    ///
     /// See the crate docs for more detail.
     ///
     /// Defaults to 4,096.

--- a/src/wheel.rs
+++ b/src/wheel.rs
@@ -81,7 +81,7 @@ impl Wheel {
         let mask = num_slots - 1;
 
         // Check that the number of slots requested is, in fact, a power of two
-        assert!(num_slots & mask == 0);
+        assert!(num_slots & mask == 0, "num_slots must be a power of two");
 
         Wheel {
             wheel: vec![Slot { head: EMPTY, next_timeout: None }; num_slots],


### PR DESCRIPTION
Document that the number of slots must be a power of two, and add a descriptive message to the associated assert.