### PR TITLE
Make it work with emscripten

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ Timer facilities for Tokio
 [dependencies]
 futures = "0.1"
 slab = "0.3.0"
+
+[target.'cfg(target_os = "emscripten")'.dependencies]
+stdweb = { version = "0.1.3", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ futures = "0.1"
 slab = "0.3.0"
 
 [target.'cfg(target_os = "emscripten")'.dependencies]
-stdweb = { version = "0.1.3", default-features = false }
+stdweb = { version = "0.4.2", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,10 @@
 extern crate futures;
 extern crate slab;
 
+#[cfg(target_os = "emscripten")]
+#[macro_use]
+extern crate stdweb;
+
 mod interval;
 mod mpmc;
 mod timer;

--- a/src/wheel.rs
+++ b/src/wheel.rs
@@ -240,6 +240,7 @@ impl Wheel {
 
     /// Returns the instant in time that corresponds to the next timeout
     /// scheduled in this wheel.
+    #[cfg_attr(target_os = "emscripten", allow(unused))]
     pub fn next_timeout(&self) -> Option<Instant> {
         // TODO: can this be optimized to not look at the whole array?
         let mut min = None;

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -5,6 +5,8 @@ use Builder;
 use mpmc::Queue;
 use wheel::{Token, Wheel};
 use futures::task::Task;
+#[cfg(target_os = "emscripten")]
+use std::cmp;
 use std::sync::Arc;
 #[cfg(target_os = "emscripten")]
 use std::sync::Mutex;
@@ -112,6 +114,7 @@ impl Worker {
         *chan.interval_id.lock().unwrap() = {
             use stdweb::unstable::TryInto;
             let interval = tolerance.as_secs() as u32 * 1000 + tolerance.subsec_nanos() / 1000000;
+            let interval = cmp::max(10, interval);      // min interval 10ms for emscripten
             let cb = move || {
                 run_once(&chan2, &mut wheel);
             };


### PR DESCRIPTION
As you probably know, threads are forbidden on emscripten, which makes this crate panic at runtime.
This PR adds support for emscripten through the `stdweb` crate.

What we do is simply call `setInterval` and run all the checks, instead of spawning a thread that loops the checks forever.
